### PR TITLE
Add pytest for grab_frame

### DIFF
--- a/test_ultrakill_env.py
+++ b/test_ultrakill_env.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+# Skip tests if Windows specific dependencies are missing
+pytest.importorskip("win32gui")
+
+from ultrakill_env import grab_frame
+
+
+def test_grab_frame_shape():
+    """grab_frame should return a 360x640 RGB image."""
+    for _ in range(3):
+        frame = grab_frame()
+        assert isinstance(frame, np.ndarray)
+        assert frame.shape == (360, 640, 3)

--- a/ultrakill_env.py
+++ b/ultrakill_env.py
@@ -343,9 +343,3 @@ class UltrakillEnv(gym.Env):
         release_all_movement_keys()
         print("Environment closed - keys released")
 
-# Smoke test
-if __name__ == "__main__":
-    for i in range(5):
-        frame = grab_frame()
-        print(frame.shape)
-        cv2.imwrite(f"test_frame_{i}.png", frame)


### PR DESCRIPTION
## Summary
- remove standalone smoke test from `ultrakill_env.py`
- add `test_ultrakill_env.py` to verify `grab_frame` returns a `(360, 640, 3)` image

## Testing
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_685609ada1088325ae1250c2b34c1922