### PR TITLE
Add survival bonus reward

### DIFF
--- a/ultrakill_env.py
+++ b/ultrakill_env.py
@@ -32,6 +32,8 @@ MOUSEEVENTF_LEFTDOWN = 0x0002
 MOUSEEVENTF_LEFTUP   = 0x0004
 
 STEP_DELAY = 0.02
+# Reward granted each step the agent stays alive
+SURVIVAL_BONUS = 0.01
 
 # Utility functions
 # Replace the existing pitch_penalty function with:
@@ -327,6 +329,8 @@ class UltrakillEnv(gym.Env):
 
         # keep your old sky/ceiling penalty too (you can scale it up):
         r -= pitch_penalty(frame, target_present)    # make that penalty twice as harsh
+        # small bonus for every step survived
+        r += SURVIVAL_BONUS
 
         # 7) Finalize
         self.prev_frame = frame.copy()


### PR DESCRIPTION
## Summary
- award a small bonus each step the character survives

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856227119548325bdae13171798cc73