### PR TITLE
Improve warmup wait logic

### DIFF
--- a/ultrakill_env.py
+++ b/ultrakill_env.py
@@ -199,7 +199,12 @@ class UltrakillEnv(gym.Env):
         while True:
             frame = grab_frame()
             if not is_score_screen(frame):
-                break
+                # Wait until the screen brightens after the fade-out
+                gray_mean = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY).mean()
+                if gray_mean > 20:
+                    break
+                time.sleep(0.1)
+                continue
                 
             # For first episode: use soft reset (Esc→Enter)
             if self.episode_id == 1:


### PR DESCRIPTION
## Summary
- wait for fade-in after scoreboard before starting warmup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685625bc94888325a11d0ec9ef732fb4