### PR TITLE
Add OCR-based health tracking

### DIFF
--- a/test_ultrakill_env.py
+++ b/test_ultrakill_env.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pytest
+import cv2
 
 # Skip tests if Windows specific dependencies are missing
 pytest.importorskip("win32gui")
 
-from ultrakill_env import grab_frame
+from ultrakill_env import grab_frame, read_health
 
 
 def test_grab_frame_shape():
@@ -13,3 +14,10 @@ def test_grab_frame_shape():
         frame = grab_frame()
         assert isinstance(frame, np.ndarray)
         assert frame.shape == (360, 640, 3)
+
+
+def test_read_health_basic():
+    frame = np.zeros((360, 640, 3), np.uint8)
+    cv2.putText(frame, "75", (10, 350), cv2.FONT_HERSHEY_SIMPLEX, 1, (255, 255, 255), 2)
+    val = read_health(frame)
+    assert val == 75


### PR DESCRIPTION
## Summary
- add OCR-based `read_health` function to detect HUD health
- report health in `reset()` and `step()` info dicts
- track health attribute in env
- test health reading on synthetic image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562e20df54832591368361d55abd6a