### PR TITLE
Add dash meter detection

### DIFF
--- a/test_ultrakill_env.py
+++ b/test_ultrakill_env.py
@@ -4,7 +4,7 @@ import pytest
 # Skip tests if Windows specific dependencies are missing
 pytest.importorskip("win32gui")
 
-from ultrakill_env import grab_frame
+from ultrakill_env import grab_frame, detect_dashes
 
 
 def test_grab_frame_shape():
@@ -13,3 +13,23 @@ def test_grab_frame_shape():
         frame = grab_frame()
         assert isinstance(frame, np.ndarray)
         assert frame.shape == (360, 640, 3)
+
+
+def test_detect_dashes_basic():
+    frame = np.zeros((360, 640, 3), np.uint8)
+    x0 = int(640 * 0.03)
+    x1 = int(640 * 0.18)
+    y0 = int(360 * 0.84)
+    y1 = int(360 * 0.89)
+    seg_w = (x1 - x0) // 3
+    color = (255, 240, 200)
+    import cv2
+    for i in range(2):
+        cv2.rectangle(
+            frame,
+            (x0 + i * seg_w + 1, y0 + 1),
+            (x0 + (i + 1) * seg_w - 1, y1 - 1),
+            color,
+            -1,
+        )
+    assert detect_dashes(frame) == 2


### PR DESCRIPTION
## Summary
- detect remaining dash charges from the light-blue dash bar
- expose `dash_count` via `UltrakillEnv` reset and step
- test dash detection on a synthetic frame

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562f5bd6ac8325b91498d192532020