### PR TITLE
Allow overriding Tesseract path

### DIFF
--- a/ultrakill_env.py
+++ b/ultrakill_env.py
@@ -10,6 +10,11 @@ from ultrakill_ai import soft_reset, send_scan, SCAN, mouse_click
 from typing import Tuple, Optional
 import ctypes.wintypes as wintypes
 
+# Allow overriding the Tesseract executable location via environment
+tesseract_override = os.environ.get("TESSERACT_CMD")
+if tesseract_override:
+    pytesseract.pytesseract.tesseract_cmd = tesseract_override
+
 # Ensure output directory exists
 os.makedirs("debug_frames", exist_ok=True)
 user32 = ctypes.windll.user32


### PR DESCRIPTION
## Summary
- let TESSERACT_CMD override pytesseract's command path
- maintain existing behaviour when the variable isn't set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856327e9eb48325afd0421c29b1d921