### PR TITLE
Fix warmup forward reset

### DIFF
--- a/ultrakill_env.py
+++ b/ultrakill_env.py
@@ -263,6 +263,9 @@ class UltrakillEnv(gym.Env):
         release_all_movement_keys()
         send_scan(SCAN["MOVE_FORWARD"])
         self.auto_forward_active = True
+        # reset timing markers so warmup duration triggers on every episode
+        self.auto_forward_start = None
+        self.auto_forward_end   = None
 
         frame = grab_frame()
         self.prev_frame = frame.copy()


### PR DESCRIPTION
## Summary
- ensure auto forward timer resets on `reset()` so every episode begins with 4s of walking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856384094688325ba318fa5146fa20f