### PR TITLE
Implement episodic PPO rollouts

### DIFF
--- a/ppo_episodes.py
+++ b/ppo_episodes.py
@@ -1,0 +1,100 @@
+
+import numpy as np
+import torch as th
+from gymnasium import spaces
+from stable_baselines3 import PPO
+from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.vec_env import VecEnv
+from stable_baselines3.common.type_aliases import RolloutBuffer
+from stable_baselines3.common.utils import obs_as_tensor
+
+
+class PPOEpisodes(PPO):
+    """PPO variant that collects rollouts based on episode count instead of step count."""
+
+    def __init__(self, *args, n_episodes: int = 1, **kwargs):
+        self.n_episodes_target = n_episodes
+        self._prev_resets = None
+        super().__init__(*args, **kwargs)
+
+    def collect_rollouts(
+        self,
+        env: VecEnv,
+        callback: BaseCallback,
+        rollout_buffer: RolloutBuffer,
+        n_rollout_steps: int,
+    ) -> bool:
+        assert self._last_obs is not None, "No previous observation was provided"
+        self.policy.set_training_mode(False)
+
+        episodes = 0
+        if self._prev_resets is None:
+            self._prev_resets = [0] * env.num_envs
+        n_steps = 0
+        rollout_buffer.reset()
+        if self.use_sde:
+            self.policy.reset_noise(env.num_envs)
+
+        callback.on_rollout_start()
+
+        while episodes < self.n_episodes_target:
+            if self.use_sde and self.sde_sample_freq > 0 and n_steps % self.sde_sample_freq == 0:
+                self.policy.reset_noise(env.num_envs)
+
+            with th.no_grad():
+                obs_tensor = obs_as_tensor(self._last_obs, self.device)
+                actions, values, log_probs = self.policy(obs_tensor)
+            actions = actions.cpu().numpy()
+            clipped_actions = actions
+            if isinstance(self.action_space, spaces.Box):
+                if self.policy.squash_output:
+                    clipped_actions = self.policy.unscale_action(clipped_actions)
+                else:
+                    clipped_actions = np.clip(actions, self.action_space.low, self.action_space.high)
+
+            new_obs, rewards, dones, infos = env.step(clipped_actions)
+            self.num_timesteps += env.num_envs
+
+            callback.update_locals(locals())
+            if not callback.on_step():
+                return False
+
+            self._update_info_buffer(infos, dones)
+            n_steps += 1
+            current_resets = [info.get("resets", prev) for info, prev in zip(infos, self._prev_resets)]
+            episodes += int(np.sum(np.array(current_resets) - np.array(self._prev_resets)))
+            self._prev_resets = current_resets
+
+            if isinstance(self.action_space, spaces.Discrete):
+                actions = actions.reshape(-1, 1)
+
+            for idx, done in enumerate(dones):
+                if (
+                    done
+                    and infos[idx].get("terminal_observation") is not None
+                    and infos[idx].get("TimeLimit.truncated", False)
+                ):
+                    terminal_obs = self.policy.obs_to_tensor(infos[idx]["terminal_observation"])[0]
+                    with th.no_grad():
+                        terminal_value = self.policy.predict_values(terminal_obs)[0]
+                    rewards[idx] += self.gamma * terminal_value
+
+            rollout_buffer.add(
+                self._last_obs,
+                actions,
+                rewards,
+                self._last_episode_starts,
+                values,
+                log_probs,
+            )
+            self._last_obs = new_obs
+            self._last_episode_starts = dones
+
+        with th.no_grad():
+            values = self.policy.predict_values(obs_as_tensor(new_obs, self.device))
+
+        rollout_buffer.compute_returns_and_advantage(last_values=values, dones=dones)
+
+        callback.update_locals(locals())
+        callback.on_rollout_end()
+        return True

--- a/train_ultrakill.py
+++ b/train_ultrakill.py
@@ -11,6 +11,7 @@ import torch
 import gymnasium as gym
 from gymnasium.wrappers import RecordEpisodeStatistics
 from stable_baselines3 import PPO
+from ppo_episodes import PPOEpisodes
 from stable_baselines3.common.vec_env import DummyVecEnv, VecTransposeImage, VecFrameStack
 from stable_baselines3.common.callbacks import CheckpointCallback
 from stable_baselines3.common.monitor import Monitor
@@ -120,11 +121,12 @@ def main():
 
     print("Instantiating PPO agent")
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    model = PPO(
+    model = PPOEpisodes(
         "CnnPolicy",
         vec,
-        # collect only 256 steps per update instead of 1024
+        # collect experience from 250 lives before each update
         n_steps=256,
+        n_episodes=250,
         # use smaller minibatches
         batch_size=64,
         verbose=1,

--- a/ultrakill_env.py
+++ b/ultrakill_env.py
@@ -229,6 +229,7 @@ class UltrakillEnv(gym.Env):
         self.prev_offset  = None
         self.t            = 0
         self.episode_id   = 0
+        self.resets       = 0
         self.dash_count   = 0
         self.health       = None
         self.auto_forward_active = False
@@ -239,6 +240,7 @@ class UltrakillEnv(gym.Env):
 
     def reset(self, *, seed=None, options=None):
         self.episode_id += 1
+        self.resets += 1
         self.t = 0
         release_all_movement_keys()
         time.sleep(0.5)
@@ -275,7 +277,11 @@ class UltrakillEnv(gym.Env):
         self.prev_frame = frame.copy()
         self.dash_count = detect_dashes(frame)
         self.health     = read_health(frame)
-        return frame, {"dash_count": self.dash_count, "health": self.health}
+        return frame, {
+            "dash_count": self.dash_count,
+            "health": self.health,
+            "resets": self.resets,
+        }
 
     def step(self, action):
         # handle our 4s auto-forward
@@ -358,7 +364,8 @@ class UltrakillEnv(gym.Env):
             self.score_screen_frames = 0
             return frame, -50.0, True, False, {
                 "dash_count": self.dash_count,
-                "health": self.health
+                "health": self.health,
+                "resets": self.resets,
             }
 
         # reward shaping...
@@ -418,7 +425,8 @@ class UltrakillEnv(gym.Env):
 
         return frame, float(r), done, False, {
             "dash_count": self.dash_count,
-            "health": self.health
+            "health": self.health,
+            "resets": self.resets,
         }
 
     def close(self):


### PR DESCRIPTION
## Summary
- create `PPOEpisodes` to gather rollouts based on episode count
- track resets in `UltrakillEnv`
- train with `PPOEpisodes` for 250 lives per update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68563fbd64148325addb671d73a16cfc